### PR TITLE
Command to view status of picked PRs

### DIFF
--- a/cmd/patchmanager/patchmanager.go
+++ b/cmd/patchmanager/patchmanager.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/mfojtik/patchmanager/pkg/cmd/approve"
-
 	"github.com/mfojtik/patchmanager/pkg/cmd/run"
+	"github.com/mfojtik/patchmanager/pkg/cmd/status"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -44,6 +44,7 @@ func NewPatchManagerCommand(ctx context.Context) *cobra.Command {
 
 	cmd.AddCommand(run.NewRunCommand(ctx))
 	cmd.AddCommand(approve.NewApproveCommand(ctx))
+	cmd.AddCommand(status.NewStatusCommand(ctx))
 
 	return cmd
 }

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -1,0 +1,96 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	v1 "github.com/mfojtik/patchmanager/pkg/api/v1"
+	"github.com/mfojtik/patchmanager/pkg/github"
+	"gopkg.in/yaml.v2"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+// statusOptions holds values to drive the status command.
+type statusOptions struct {
+	githubToken string
+	inFile      string
+}
+
+// NewStatusCommand creates a status command.
+func NewStatusCommand(ctx context.Context) *cobra.Command {
+	runOpts := statusOptions{}
+	cmd := &cobra.Command{
+		Use: "status",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runOpts.Complete(); err != nil {
+				klog.Exit(err)
+			}
+			if err := runOpts.Validate(); err != nil {
+				klog.Exit(err)
+			}
+			if err := runOpts.Run(ctx); err != nil {
+				klog.Exit(err)
+			}
+		},
+	}
+
+	runOpts.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (r *statusOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&r.githubToken, "github-token", "", "Github Access Token (GITHUB_TOKEN env variable)")
+	fs.StringVarP(&r.inFile, "file", "f", "", "Set input file to read the list of candidates")
+}
+
+func (r *statusOptions) Validate() error {
+	if len(r.githubToken) == 0 {
+		return fmt.Errorf("github-token flag must be specified or GITHUB_TOKEN environment must be set")
+	}
+	if len(r.inFile) == 0 {
+		return fmt.Errorf("input file must be specified")
+	}
+	return nil
+}
+
+func (r *statusOptions) Complete() error {
+	if len(r.githubToken) == 0 {
+		r.githubToken = os.Getenv("GITHUB_TOKEN")
+	}
+	return nil
+}
+
+func (r *statusOptions) Run(ctx context.Context) error {
+	content, err := ioutil.ReadFile(r.inFile)
+	if err != nil {
+		return err
+	}
+
+	var approved v1.ApprovedCandidateList
+
+	if err := yaml.Unmarshal(content, &approved); err != nil {
+		return err
+	}
+
+	status := github.NewPullRequestStatusViewer(ctx, r.githubToken)
+
+	for _, pr := range approved.Items {
+		if pr.PullRequest.Decision != "pick" {
+			continue
+		}
+
+		if err := status.Merged(ctx, pr.PullRequest.URL); err != nil {
+			fmt.Fprintf(os.Stdout, "%q: %v\n", pr.PullRequest.URL, err)
+		} else {
+			fmt.Fprintf(os.Stdout, "%q: merged\n", pr.PullRequest.URL)
+		}
+	}
+
+	return nil
+}

--- a/pkg/github/approver.go
+++ b/pkg/github/approver.go
@@ -30,10 +30,10 @@ func (p *PullRequestApprover) CherryPickApprove(ctx context.Context, url string)
 
 func parsePullRequestMeta(u string) (string, string, int, error) {
 	parts := strings.Split(strings.TrimPrefix(u, "https://github.com/"), "/")
-	if len(parts) != 3 {
+	if len(parts) != 4 {
 		return "", "", 0, fmt.Errorf("unable to parse pull request url %q", u)
 	}
-	number, err := strconv.Atoi(parts[2])
+	number, err := strconv.Atoi(parts[3])
 	if err != nil {
 		return "", "", 0, err
 	}

--- a/pkg/github/status.go
+++ b/pkg/github/status.go
@@ -1,0 +1,31 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"golang.org/x/oauth2"
+
+	"github.com/google/go-github/v32/github"
+)
+
+type StatusViewer struct {
+	client *github.Client
+}
+
+func NewPullRequestStatusViewer(ctx context.Context, ghToken string) *StatusViewer {
+	return &StatusViewer{client: github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: ghToken})))}
+}
+
+func (p *StatusViewer) Merged(ctx context.Context, url string) error {
+	owner, repo, number, err := parsePullRequestMeta(url)
+	if err != nil {
+		return err
+	}
+	merged, _, err := p.client.PullRequests.IsMerged(ctx, owner, repo, number)
+	_, _, err = p.client.Issues.AddLabelsToIssue(ctx, owner, repo, number, []string{"cherry-pick-approved"})
+	if err == nil && merged == false {
+		err = fmt.Errorf("not merged")
+	}
+	return err
+}
+


### PR DESCRIPTION
This adds a command that reports the current status of all PRs given an input candidate file:

For example:
```sh
$ patchmanager status -f candidates-4.7.yaml
"https://github.com/openshift/cluster-network-operator/pull/1017": not merged
"https://github.com/openshift/whereabouts-cni/pull/49": merged
"https://github.com/operator-framework/operator-lifecycle-manager/pull/2034": not merged
"https://github.com/openshift/origin/pull/25884": not merged
```

We may want to bikeshed on the output, but for now this saved me a bit of time reviewing the current merge status.